### PR TITLE
Add info about how to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ It is a way to extend stock, stable cargo with custom commands (`xtasks`), writt
 This polyfill doesn't need any code, just a particular configuration of a cargo project.
 This repository serves as a specification of such configuration.
 
+## Installation
+
+```sh
+cargo install --git https://github.com/matklad/cargo-xtask xtask
+```
+
 ## Defining xtasks
 
 In the root of the project repository, there should be an `xtask` directory, which is a cargo crate with one binary target.


### PR DESCRIPTION
 because it's not published to crates.io yet

(to complete rust-analyzer binary install instructions which link here)