### PR TITLE
Add link to devx crates in tooling chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,9 @@ See [#1](https://github.com/matklad/cargo-xtask/issues/1) for discussion.
 
 ## Tooling
 
-There's no specific tooling to support xtasks at the moment.
+Libraries:
+- [devx](https://github.com/elastio/devx): collection of useful utilities (spawning processes, git pre-commit hooks, etc.)
+
 If you write tools or libraries for xtasks, send a PR to this document.
 Some possible ideas:
 


### PR DESCRIPTION
Wanted to share what we have open-sourced from our `xtask` support utilities.
This is quite raw, but seems to be useful.
There isn't too much code (but enough docs).

@matklad I would like to ask you for a small review at least for [`devx-cmd` crate](https://github.com/elastio/devx/blob/master/devx-cmd/src/lib.rs)
One of the rough edges there is logging. Having expcicit `echo_cmd()` and `echo_err()` methods seem not the best solution to me, but I just borrowed this in part from `rust-analyzer`'s xtask.
I though about using `log` crate which is quite low-overhead, but I haven't found a logger implementation that uses `stderr` and uses no extra deps. [`simple_logger`](https://github.com/borntyping/rust-simple_logger/blob/master/src/lib.rs) seems like the perfect candidate, but it uses `println!` instead of `eprinln!` :(

If you are interested in aggregating more utilities for `xtask` in `devx`, let me know and I'll be happy to share the repo permissions