### PR TITLE
Give cargo config a .toml suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Then, the alias. This is where the magic happens. Create a `.cargo`:
 $ mkdir .cargo
 ```
 
-and create a file in it named `config` with these contents:
+and create a file in it named `config.toml` with these contents:
 
 ```toml
 [alias]


### PR DESCRIPTION
Having the `.toml` is nice for syntax highlighting etc.

It doesn't seem to be officially documented that you can call the config file `config.toml` and not just `config` but it [works for me](https://github.com/azdavis/millet/blob/4f664ad042f5a59e40506630e7c714e74e665f50/.cargo/config.toml).