### PR TITLE
Doc: Prefix suggested `mv` commands with `git`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ is named "testing." We first move everything into a sub-directory:
 $ mkdir testing
 
 # then move all of the stuff except your .git directory into the new testing directory:
-$ mv src testing
-$ mv Cargo.toml testing
-$ mv .gitignore testing
-$ mv README.md testing
+$ git mv src testing
+$ git mv Cargo.toml testing
+$ git mv .gitignore testing
+$ git mv README.md testing
 
 # Don't forget anything else your package may have.
 ```


### PR DESCRIPTION
Since we're editing an exiting Git repo in the README's example, it's easier to commit the changes if we use `git mv` instead of `mv`.