### PR TITLE
fix: Rename `config` to `config.toml` in example

### DIFF
--- a/examples/hello-world/.cargo/config
+++ b/examples/hello-world/.cargo/config
@@ -1,2 +1,0 @@
-[alias]
-xtask = "run --manifest-path ./xtask/Cargo.toml --"

--- a/examples/hello-world/.cargo/config.toml
+++ b/examples/hello-world/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --manifest-path ./xtask/Cargo.toml --"


### PR DESCRIPTION
`.cargo/config` is deprecated