### PR TITLE
Simplify workspace creation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,26 +25,20 @@ It might or might not work for your use case!
 
 ## Defining xtasks
 
-The best way to create an xtask is to do so inside of a Cargo workspace. If you don't have a workspace already,
-you can create one inside your package by moving the contents into a new directory. Let's say that our package
-is named "testing." We first move everything into a sub-directory:
+The best way to create an xtask is to do so inside of a Cargo workspace. If you don't have a workspace already you can issue the steps below. We should end up with `my_workspace/.git`, `my_workspace/testing` where `testing` is your package name:
 
 ```console
-$ mkdir testing
-
-# then move all of the stuff except your .git directory into the new testing directory:
-$ mv src testing
-$ mv Cargo.toml testing
-$ mv .gitignore testing
-$ mv README.md testing
-
-# Don't forget anything else your package may have.
+mkdir my_workspace
+# the original .git must be moved to my_workspace
+mv testing/.git my_workspace
+mv testing my_workspace
+cd my_workspace
 ```
 
 Then, add a new package named `xtask`:
 
 ```console
-$ cargo new --bin xtask
+cargo new --bin xtask
 ```
 
 Then, we need to create a `Cargo.toml` for our workspace:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ xtask = "run --package xtask --"
 Example directory layout:
 
 ```
-/testing
+/my_workspace
   .git
   .cargo/
     config.toml
@@ -88,7 +88,7 @@ Example directory layout:
 
 Both the `xtask` directory and the `.cargo/config` should be committed to the version control system.
 
-If you don't want to use a workspace, you can use `run --manifest-path ./xtask/Cargo.toml --` for the alias, but this is not recommended.
+If you don't want to use a workspace, you can use `run --manifest-path ./xtask/Cargo.toml --` for the alias (as in the example folder), but this is not recommended.
 
 The `xtask` binary should expect at least one positional argument, which is a name of the task to be executed.
 Tasks are implemented in Rust, and can use arbitrary crates from crates.io.


### PR DESCRIPTION
* Instead of moving files, it is easier to move "testing" directly, excepting the `.git`. 
* I also removed the `$` so that we can copy the code to test.